### PR TITLE
Specify POD character encoding (UTF-8)

### DIFF
--- a/WWW-YoutubeViewer/lib/WWW/YoutubeViewer.pm
+++ b/WWW-YoutubeViewer/lib/WWW/YoutubeViewer.pm
@@ -8,6 +8,8 @@ use strict;
 use autouse 'XML::Fast'   => qw{ xml2hash($;%) };
 use autouse 'URI::Escape' => qw{ uri_escape uri_escape_utf8 uri_unescape };
 
+=encoding utf8
+
 =head1 NAME
 
 WWW::YoutubeViewer - A very easy interface to YouTube.


### PR DESCRIPTION
This fixes a test failure of Test::Pod, at least on Perl 5.18 (Test::Pod 1.48):

```
t/pod.t ........... 1/7
#   Failed test 'POD test for blib/lib/WWW/YoutubeViewer.pm'
#   at /usr/share/perl5/Test/Pod.pm line 186.
Wide character in print at /usr/share/perl/5.18/Test/Builder.pm line 1759.
# blib/lib/WWW/YoutubeViewer.pm (1981): Non-ASCII character seen before =encoding in 'Șuteu,'. Assuming UTF-8
```
