### PR TITLE
YoutubeViewer: Move youtube-dl support to its own pairer.

### DIFF
--- a/lib/WWW/YoutubeViewer.pm
+++ b/lib/WWW/YoutubeViewer.pm
@@ -544,6 +544,18 @@ sub get_video_tops {
     ...    # NEEDS WORK!!!
 }
 
+sub _get_ytdl_url {
+    my ($self, $videoID) = @_;
+
+    return '' if ((state $x = $self->proxy_system('youtube-dl', '--version')) == 0);
+
+    chomp(my $url = $self->proxy_stdout('youtube-dl',
+        '--get-url', '--format', 'best',
+        '"http://www.youtube.com/watch?v=' . $videoID . '"'));
+
+    return $url;
+}
+
 sub _get_pairs_from_info_data {
     my ($self, $content, $videoID) = @_;
 
@@ -569,10 +581,9 @@ sub _get_pairs_from_info_data {
                 $hash_ref->{url} .= "&signature=$hash_ref->{sig}";
             }
             elsif (exists $hash_ref->{s}) {    # has an encrypted signature :(
-                if ((state $x = $self->proxy_system('youtube-dl', '--version')) == 0) {    # true if youtube-dl is installed
-
-                    # Unfortunately, this streaming URLs doesn't work with 'mplayer', but they work with 'mpv' and 'vlc'
-                    chomp(my $url = `youtube-dl --get-url --format best "http://www.youtube.com/watch?v=$videoID"`);
+                # Unfortunately, this streaming URLs doesn't work with 'mplayer', but they work with 'mpv' and 'vlc'
+                my $url = $self->_get_ytdl_url($videoID);
+                if ($url ne '') {
                     foreach my $item (@array) {
                         if (exists $item->{url}) {
                             $item->{url} = $url;
@@ -702,7 +713,7 @@ sub get_video_comments {
     }
 
     # Create proxy_{exec,system} subroutines
-    foreach my $name ('exec', 'system') {
+    foreach my $name ('exec', 'system', 'stdout') {
         *{__PACKAGE__ . '::proxy_' . $name} = sub {
             my ($self, @args) = @_;
 
@@ -716,6 +727,9 @@ sub get_video_comments {
             }
             elsif ($name eq 'system') {
                 system @args;
+            }
+            elsif ($name eq 'stdout') {
+                return qx/@args/;
             }
         };
     }


### PR DESCRIPTION
This effectively allows you to use youtube-dl entirely to find all of the urls
and formats of a specific video. Thanks to these changes encrypted videos now
use the format decided by the user.

Based on #87, could be rebased.