### PR TITLE
gtk-youtube-viewer: add option mainw_centered (default 0) to set the …

### DIFF
--- a/bin/gtk-youtube-viewer
+++ b/bin/gtk-youtube-viewer
@@ -204,6 +204,7 @@ my %CONFIG = (
     mainw_size                  => '700x400',
     mainw_maximized             => 0,
     mainw_fullscreen            => 0,
+    mainw_centered              => 0,
 
     # Youtube options
     dash_support    => 1,
@@ -825,8 +826,11 @@ sub apply_configuration {
     $resolution_combobox->set_active($CONFIG{active_resolution_combobox});
     $safesearch_combobox->set_active($CONFIG{active_safeSearch_combobox});
 
-    # Resize the main window
+    # Resize (and possibly center) the main window
     $mainw->set_default_size(split(/x/i, $CONFIG{mainw_size}, 2));
+    if ($CONFIG{mainw_centered}) {
+        $mainw->set_position("center");
+    }
     $mainw->reshow_with_initial_size;
 
     if ($CONFIG{mainw_maximized}) {


### PR DESCRIPTION
…initial window position to 'center'

When starting gtk-youtube-viewer the window is created where I click the launcher (dock or panel) or run where the command (terminal). My personal preference is to have it start centered on the screen I usually just manually add a line to gtk-youtube-viewer after installation, where I set the initial position of the window to `"center" `

`$mainw->set_position("center");`

I don't know whether this is appreciated or considered useful or bloat but I thought I'd create a pull request which adds a new config option `mainw_centered` (`0` or `1`, defaults to `0`) and have the centered position set after the window is resized to the size given in the config file (after which it is rerendered `$mainw->reshow_with_initial_size;`).

Feel free to reject.