### PR TITLE
Feature: navigate back and forth

### DIFF
--- a/bin/gtk-youtube-viewer
+++ b/bin/gtk-youtube-viewer
@@ -3021,6 +3021,7 @@ sub add_results_to_history
 		no warnings 'misc';
 		splice @{$ResultsHistory->{results}}, $ResultsHistory->{current}, 0, $results_copy;
 	}
+	set_prev_next_results_sensitivity();
 }
 sub display_previous_results
 {
@@ -3045,6 +3046,12 @@ sub display_relative_results
 	require Storable;
 	my $results_copy = Storable::dclone($ResultsHistory->{results}->[$nth_item]);
 	display_results($results_copy, 1);
+	set_prev_next_results_sensitivity();
+}
+sub set_prev_next_results_sensitivity
+{
+	$gui->get_object('show_prev_results')->set_sensitive($ResultsHistory->{current} > 0);
+	$gui->get_object('show_next_results')->set_sensitive($ResultsHistory->{current} < $#{$ResultsHistory->{results}});
 }
 
 sub show_videos_from_selected_author {

--- a/bin/gtk-youtube-viewer
+++ b/bin/gtk-youtube-viewer
@@ -735,6 +735,11 @@ if (not defined $CONFIG{terminal}) {
     $key =~ s/(.{$i})(.)/$2$1/g while --$i;
 }
 
+my $ResultsHistory = {
+	current => -1,
+	results => [],
+};
+
 # Locate youtube-viewer
 $CONFIG{youtube_viewer} //= which_command('youtube-viewer') // 'youtube-viewer';
 
@@ -2325,11 +2330,13 @@ sub _get_pixbuf_thumbnail {
 }
 
 sub display_results {
-    my ($results) = @_;
+    my ($results, $dont_append_to_results_history) = @_;
 
     if (not $yv_utils->has_entries($results)) {
         die "No results...\n";
     }
+
+	add_results_to_history($results) unless $dont_append_to_results_history;
 
     my $url   = $results->{url};
     my $info  = $results->{results} // {};
@@ -3002,6 +3009,42 @@ sub display_comments {
     }
 
     return 1;
+}
+
+sub add_results_to_history
+{
+	my ($results) = @_;
+	require Storable;
+	my $results_copy = Storable::dclone($results);
+	$ResultsHistory->{current}++;
+	{
+		no warnings 'misc';
+		splice @{$ResultsHistory->{results}}, $ResultsHistory->{current}, 0, $results_copy;
+	}
+}
+sub display_previous_results
+{
+	if($ResultsHistory->{current} > 0)
+	{
+		$ResultsHistory->{current}--;
+		display_relative_results($ResultsHistory->{current});
+	}
+}
+sub display_next_results
+{
+	if($ResultsHistory->{current} < $#{$ResultsHistory->{results}})
+	{
+		$ResultsHistory->{current}++;
+		display_relative_results($ResultsHistory->{current});
+	}
+}
+sub display_relative_results
+{
+	my ($nth_item) = @_;
+	$liststore->clear if $CONFIG{clear_search_list};
+	require Storable;
+	my $results_copy = Storable::dclone($ResultsHistory->{results}->[$nth_item]);
+	display_results($results_copy, 1);
 }
 
 sub show_videos_from_selected_author {

--- a/share/gtk-youtube-viewer.glade
+++ b/share/gtk-youtube-viewer.glade
@@ -316,6 +316,7 @@
                     <child>
                       <object class="GtkImageMenuItem" id="show_prev_results">
                         <property name="label" translatable="yes">Previous results</property>
+                        <property name="sensitive">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_stock">False</property>
@@ -326,6 +327,7 @@
                     <child>
                       <object class="GtkImageMenuItem" id="show_next_results">
                         <property name="label" translatable="yes">Next results</property>
+                        <property name="sensitive">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_stock">False</property>

--- a/share/gtk-youtube-viewer.glade
+++ b/share/gtk-youtube-viewer.glade
@@ -126,6 +126,16 @@
     <property name="can_focus">False</property>
     <property name="icon_name">mail-send</property>
   </object>
+  <object class="GtkImage" id="icon-next">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-go-forward</property>
+  </object>
+  <object class="GtkImage" id="icon-previous">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-go-back</property>
+  </object>
   <object class="GtkListStore" id="liststore1">
     <columns>
       <!-- column-name name -->
@@ -303,6 +313,26 @@
                   <object class="GtkMenu" id="main-menu-view-menu">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkImageMenuItem" id="show_prev_results">
+                        <property name="label" translatable="yes">Previous results</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_stock">False</property>
+                        <property name="image">icon-previous</property>
+                        <signal name="activate" handler="display_previous_results" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="show_next_results">
+                        <property name="label" translatable="yes">Next results</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_stock">False</property>
+                        <property name="image">icon-next</property>
+                        <signal name="activate" handler="display_next_results" swapped="no"/>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/share/gtk-youtube-viewer.glade
+++ b/share/gtk-youtube-viewer.glade
@@ -295,6 +295,19 @@
               </object>
             </child>
             <child>
+              <object class="GtkMenuItem" id="main-menu-view">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">View</property>
+                <child type="submenu">
+                  <object class="GtkMenu" id="main-menu-view-menu">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkMenuItem" id="menuitem4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>


### PR DESCRIPTION
this pr adds a 'View' menu to the main menu with a 'Previous' and a 'Next' menuitems, which displays the previous and next search results respectively.

search results are stored in a global hash by deep-copying `$results` reference which `display_results()` gets as first argument.

this feature makes more sense with `clear_search_list=1` config option.

this pr addresses #215