### PR TITLE
Mention FreeBSD instead of FreshPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A lightweight application for searching and streaming videos from YouTube.
 * Arch Linux (community): https://www.archlinux.org/packages/community/any/youtube-viewer/
 * Arch Linux (AUR): https://aur.archlinux.org/packages/gtk-youtube-viewer-git/
 * Fedora: https://build.opensuse.org/package/show/home:zhonghuaren/youtube-viewer
-* Fresh ports: http://www.freshports.org/multimedia/gtk-youtube-viewer
+* FreeBSD: http://www.freshports.org/multimedia/gtk-youtube-viewer
 * Frugalware: http://frugalware.org/packages/203103
 * Gentoo: https://packages.gentoo.org/package/net-misc/youtube-viewer
 * Puppy Linux: http://www.murga-linux.com/puppy/viewtopic.php?t=76835


### PR DESCRIPTION
FreshPorts is a third-party website to describe FreeBSD Ports, FreeBSD Ports is the actual packaging system of FreeBSD.