### PR TITLE
Fix for the issue #367

### DIFF
--- a/lib/WWW/YoutubeViewer/Utils.pm
+++ b/lib/WWW/YoutubeViewer/Utils.pm
@@ -98,7 +98,7 @@ sub format_time {
     my ($self, $sec) = @_;
     $sec >= 3600
       ? join q{:}, map { sprintf '%02d', $_ } $sec / 3600 % 24, $sec / 60 % 60, $sec % 60
-      : join q{:}, map { sprintf '%02d', $_ } $sec / 60 % 60, $sec % 60;
+      : "   " . join q{:}, map { sprintf '%02d', $_ } $sec / 60 % 60, $sec % 60;
 }
 
 =head2 format_duration($duration)


### PR DESCRIPTION
Fixed format_time sub (return time string with 3 space prefix if the time is shorter than 1 hour)