### PR TITLE
Increase the download speed

### DIFF
--- a/bin/gtk-youtube-viewer
+++ b/bin/gtk-youtube-viewer
@@ -188,7 +188,7 @@ my %CONFIG = (
                               srt   => q{--sub-file=*SUB*},
                               audio => q{--audio-file=*AUDIO*},
                               fs    => q{--fullscreen},
-                              arg   => q{--really-quiet --force-media-title=*TITLE* --no-ytdl --no-terminal *VIDEO*},
+                              arg   => q{--really-quiet --force-media-title=*TITLE* --stream-lavf-o-append=request_size=10485760 --no-ytdl --no-terminal *VIDEO*},
                              },
                       mpvraw => {
                                  arg => q{--ytdl-raw-options-append="format-sort=ext,res:*RESOLUTION*" --no-terminal *URL*},

--- a/bin/youtube-viewer
+++ b/bin/youtube-viewer
@@ -214,7 +214,7 @@ my %CONFIG = (
                 srt     => q{--sub-file=*SUB*},
                 audio   => q{--audio-file=*AUDIO*},
                 fs      => q{--fullscreen},
-                arg     => q{--really-quiet --force-media-title=*TITLE* --no-ytdl *VIDEO*},
+                arg     => q{--really-quiet --force-media-title=*TITLE* --stream-lavf-o-append=request_size=10485760 --no-ytdl *VIDEO*},
                 novideo => q{--no-video},
                },
 


### PR DESCRIPTION
Use the request_size option added to ffmpeg 8.1 to download 10MB at a time and bypass Youtube's throttling.

The option is silently ignored on older ffmpeg versions.

Fixes #416.